### PR TITLE
pass store into Counter as per description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <Counter />
+        <Counter store={this.props.store} />
       </div>
     );
   };


### PR DESCRIPTION
The code-along wasn't working as written, because the `<Counter />` component didn't get the store as a prop.

Previously:

>We now want to add the __Counter__ Component to to the `./src/App.js` Component and pass in the store as props.
>
>```jsx
>// ./src/App.js
>
>import React, { Component } from 'react';
>import Counter from './components/Counter';
>
>class App extends Component {
>  render() {
>    return (
>      <div className="App">
>        <Counter />
>      </div>
>    );
>  };
>};
>
>export default App;
>```

...now:

```jsx
// ...
      <div className="App">
        <Counter store={this.props.store} />
      </div>
// ...
```

Fixes https://github.com/learn-co-curriculum/integrating-react-and-redux-codealong/issues/5